### PR TITLE
Slow down elevator for gearvr

### DIFF
--- a/fallen.html
+++ b/fallen.html
@@ -227,7 +227,7 @@ Facebook   Kousuke Tanabe(eating chicken feet guy icon)
 
 <a-entity>
 <a-obj-model src="bill1-2f/tower3elevetor.obj.txt" mtl="bill1-2f/tower3elevetor.mtl" n-mesh-collider="type: environment; convex: true" scale="1 1 1">
-<a-animation  attribute="position" direction="alternate" dur="15000" to="0 58 0" repeat="indefinite"> </a-animation>
+<a-animation  attribute="position" direction="alternate" dur="20000" to="0 58 0" repeat="indefinite"> </a-animation>
 </a-obj-model>
 </a-entity>
 


### PR DESCRIPTION
Elevator was too fast for Gear VR. Users would fall through while it was moving.